### PR TITLE
Add rake console command to load Rubies into irb session

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,3 +5,8 @@ RSpec::Core::RakeTask.new(:spec) do |t|
   t.pattern = 'spec/*/*_spec.rb'
 end
 
+desc "Open an irb session preloaded with this library"
+task :console do
+  sh "irb -rubygems -I lib -r rubies.rb"
+end
+


### PR DESCRIPTION
By calling ‘rake console’, irb will run with the Rubies module loaded into state to allow for easier development and debugging of the gem.